### PR TITLE
Specify negative ints as signed chars in tests.

### DIFF
--- a/src/test/PrimeField.cpp
+++ b/src/test/PrimeField.cpp
@@ -59,9 +59,9 @@ TEST(PrimeField, toElement) {
     toString(pf.toElement(std::numeric_limits<int>::min())));
 
   // Fewer number of bits (8)
-  ASSERT_EQ("127", toString(pf.toElement(std::numeric_limits<char>::max())));
+  ASSERT_EQ("127", toString(pf.toElement(std::numeric_limits<signed char>::max())));
   ASSERT_EQ("4294967163",
-    toString(pf.toElement(std::numeric_limits<char>::min())));
+    toString(pf.toElement(std::numeric_limits<signed char>::min())));
 
   ASSERT_EQ("255",
     toString(pf.toElement(std::numeric_limits<unsigned char>::max())));

--- a/src/test/Scanner.cpp
+++ b/src/test/Scanner.cpp
@@ -102,10 +102,10 @@ TEST(Scanner, readInteger) {
   ASSERT_EQ(0, in.readInteger<unsigned char>());
   ASSERT_EQ(0, in.readInteger<char>());
   ASSERT_EQ(1, in.readInteger<char>());
-  ASSERT_EQ(-1, in.readInteger<char>());
+  ASSERT_EQ(-1, in.readInteger<signed char>());
   ASSERT_EQ(127, in.readInteger<char>());
-  ASSERT_EQ(-128, in.readInteger<char>());
-  ASSERT_EQ(-128, in.readInteger<char>(true));
+  ASSERT_EQ(-128, in.readInteger<signed char>());
+  ASSERT_EQ(-128, in.readInteger<signed char>(true));
 }
 
 TEST(Scanner, WhiteAndLineCount) {


### PR DESCRIPTION
This fixes failed tests on several architectures for which the default
char is unsigned.
