### PR TITLE
Restore libtool but with disable-shared option.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,11 +6,14 @@ ACLOCAL_AMFLAGS = -I build/autotools/m4
 AM_CPPFLAGS = -I${top_srcdir}/ -I$(top_srcdir)/src/ $(DEPS_CFLAGS)
 
 # tell Libtool what the name of the library is.
-lib_LIBRARIES = libmathicgb.a
+lib_LTLIBRARIES = libmathicgb.la
+
+# libraries that are needed by this library
+libmathicgb_la_LIBADD= $(DEPS_LIBS)
 
 # the sources that are built to make libmathicgb. Listing the headers in
 # sources ensure that those files are included in distributions.
-libmathicgb_a_SOURCES = src/mathicgb/MonoArena.hpp						\
+libmathicgb_la_SOURCES = src/mathicgb/MonoArena.hpp						\
   src/mathicgb/Range.hpp src/mathicgb/ReducerPack.hpp					\
   src/mathicgb/ReducerPack.cpp src/mathicgb/ClassicGBAlg.cpp			\
   src/mathicgb/ClassicGBAlg.hpp src/mathicgb/MonoLookup.hpp				\
@@ -82,7 +85,7 @@ mgb_SOURCES = src/cli/GBMain.cpp src/cli/CommonParams.hpp		\
   src/cli/MatrixAction.cpp src/cli/MatrixAction.hpp			\
   src/cli/SigGBAction.hpp src/cli/SigGBAction.cpp			\
   src/cli/HelpAction.hpp src/cli/HelpAction.cpp
-mgb_LDADD = $(top_builddir)/libmathicgb.a $(DEPS_LIBS) -lmathic -lmemtailor -lpthread
+mgb_LDADD = $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lmathic -lmemtailor -lpthread
 
 # set up tests to run on "make check"
 if with_gtest
@@ -93,7 +96,7 @@ check_PROGRAMS=$(TESTS)
 # this prevents g++ 4.8.2 from crashing and churning through memory when compiling under Ubuntu 64 14.04.1
 src/test/MonoMonoid.o src/test/Range.o : CXXFLAGS += -O0
 
-unittest_LDADD = $(DEPS_LIBS) $(top_builddir)/libmathicgb.a $(DEPS_LIBS) -lmathic -lmemtailor -lpthread
+unittest_LDADD = $(DEPS_LIBS) $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lmathic -lmemtailor -lpthread
 
 test_LIBS=
 unittest_SOURCES=src/test/Range.cpp src/test/gtestInclude.cpp			\

--- a/configure.ac
+++ b/configure.ac
@@ -174,7 +174,9 @@ AC_PROG_LN_S
 # Requires install-sh to be present as a fallback, even on systems where
 # the fallback is not used.
 AC_PROG_INSTALL
-AC_PROG_RANLIB
+
+# Set up LibTool
+LT_INIT([disable-shared])
 
 dnl Set the version for the library -- this concerns compatibility of the
 dnl source and binary interface of the library and is not the same as the
@@ -183,7 +185,8 @@ AC_SUBST([MATHICGB_SO_VERSION], [0:0:0])
 
 dnl Set up AC_OUTPUT to create each file by copying an input file
 dnl while substituting the output variable values.
-AC_CONFIG_FILES([Makefile build/autotools/mathicgb.pc])
+AC_CONFIG_FILES([Makefile
+  build/autotools/mathicgb.pc:build/autotools/mathicgb.pc.in])
 
 dnl Macro that is required to be at the end of any Autoconf script.
 dnl Creates config.status and launches it.


### PR DESCRIPTION
This reverts commit 2f4d661, but the addition of the disable-shared option
still prevents the building of shared libraries by default.

If shared libraries are desired (e.g., for the Debian package), users may
run ./configure --enable-shared.
