### PR TITLE
Only link tests against gtest

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -97,7 +97,7 @@ check_PROGRAMS=$(TESTS)
 # this prevents g++ 4.8.2 from crashing and churning through memory when compiling under Ubuntu 64 14.04.1
 src/test/MonoMonoid.o src/test/Range.o : CXXFLAGS += -O0
 
-unittest_LDADD = $(DEPS_LIBS) $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lmathic -lmemtailor -lpthread
+unittest_LDADD = $(DEPS_LIBS) $(top_builddir)/libmathicgb.la $(DEPS_LIBS) $(GTEST_LIBS) -lmathic -lmemtailor -lpthread
 
 test_LIBS=
 unittest_SOURCES=src/test/Range.cpp src/test/gtestInclude.cpp			\

--- a/configure.ac
+++ b/configure.ac
@@ -130,10 +130,11 @@ AS_IF([test "x$with_tbb" == "xyes"],
 )
 
 DEPS_CFLAGS="$MEMTAILOR_CFLAGS $MATHIC_CFLAGS $TBB_CFLAGS $GTEST_CFLAGS"
-DEPS_LIBS="$MEMTAILOR_LIBS $MATHIC_LIBS $TBB_LIBS $GTEST_LIBS $RT_LIBS"
+DEPS_LIBS="$MEMTAILOR_LIBS $MATHIC_LIBS $TBB_LIBS $RT_LIBS"
 
 AC_SUBST(DEPS_CFLAGS)
 AC_SUBST(DEPS_LIBS)
+AC_SUBST(GTEST_LIBS)
 
 # Enable optional maintainer mode (off by default)
 dnl AM_MAINTAINER_MODE turns off automatic reconstruction of the build


### PR DESCRIPTION
mgb should not be linked against gtest, only the unittests.
