### PR TITLE
Properly link against mathic and memtailor.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -86,7 +86,7 @@ mgb_SOURCES = src/cli/GBMain.cpp src/cli/CommonParams.hpp		\
   src/cli/MatrixAction.cpp src/cli/MatrixAction.hpp			\
   src/cli/SigGBAction.hpp src/cli/SigGBAction.cpp			\
   src/cli/HelpAction.hpp src/cli/HelpAction.cpp
-mgb_LDADD = $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lmathic -lmemtailor -lpthread
+mgb_LDADD = $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lpthread
 
 # set up tests to run on "make check"
 if with_gtest
@@ -97,7 +97,7 @@ check_PROGRAMS=$(TESTS)
 # this prevents g++ 4.8.2 from crashing and churning through memory when compiling under Ubuntu 64 14.04.1
 src/test/MonoMonoid.o src/test/Range.o : CXXFLAGS += -O0
 
-unittest_LDADD = $(DEPS_LIBS) $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lmathic -lmemtailor -lpthread
+unittest_LDADD = $(DEPS_LIBS) $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lpthread
 
 test_LIBS=
 unittest_SOURCES=src/test/Range.cpp src/test/gtestInclude.cpp			\

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,8 @@ AC_CONFIG_SRCDIR([src/mathicgb.h])
 # Check availability and location of dependencies
 # PKG_CHECK_MODULES([MEMTAILOR], [memtailor])
 # PKG_CHECK_MODULES([MATHIC], [mathic])
+MEMTAILOR_LIBS="-lmemtailor"
+MATHIC_LIBS="-lmathic"
 
 # Locate the C++ compiler.
 AC_PROG_CXX


### PR DESCRIPTION
In 691edb2, the use of pkg-config to get the library names of mathic and
memtailor was dropped.  Instead, they were manually added when linking
the mgb binary and the unit tests.

However, they were not manually added to the linking of the libmathicgb
library, causing underlinking.  For example, from the build logs of the
Debian package:

    dpkg-shlibdeps: warning: symbol _ZN6mathic13ColumnPrinter11bytesInUnitB5cxx11Ey used by debian/libmathicgb0/usr/lib/i386-linux-gnu/libmathicgb.so.0.0.0 found in none of the libraries

In this patch, we instead define MATHIC_LIBS and MEMTAILOR_LIBS, which
used to be defined by pkg-config.  The library names are then included
with DEPS_LIBS.