### PR TITLE
Fix cross building by using test -f instead of AC_CHECK_FILE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AS_IF([test "x$GTEST_VERSION" == "x"], [GTEST_VERSION="1.6.0"])
 AS_IF([test "x$with_gtest" == "x"], [with_gtest="download"])
 
 AS_IF([test "x$with_gtest" == "xdownload"],
-  [with_gtest="yes"; AC_CHECK_FILE([$GTEST_PATH/src/gtest-all.cc], [], [
+  [with_gtest="yes"; AS_IF([test -f "$GTEST_PATH/src/gtest-all.cc"], [], [
     echo "downloading of gtest disabled" >&2; exit 1
     mkdir -p "$GTEST_PATH";
     (
@@ -62,7 +62,7 @@ AS_IF([test "x$with_gtest" == "xdownload"],
     fi
   ])],
   [test "x$with_gtest" == "xyes"], [
-    AC_CHECK_FILE([$GTEST_PATH/src/gtest-all.cc], [], [
+    AS_IF([test -f "$GTEST_PATH/src/gtest-all.cc"], [], [
       AC_MSG_ERROR([could not find gtest source at path $GTEST_PATH.])
     ])
   ],


### PR DESCRIPTION
From Debian bug #929037 [1], reported by Helmut Grohne <helmut@subdivi.de>:

  mathicgb fails to cross build from source, because it abuses
  AC_CHECK_FILE to discover source files on the build machine. The macro
  is meant to check for files on the host. Please use simple "test -f"
  here. The attached patch makes mathicgb cross buildable. Please consider
  applying it.

  Helmut

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=929037