### PR TITLE
add missing header directory for tbb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ target_include_directories(mathicgb
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:include>
+    $<$<BOOL:${with_tbb}>:${TBB_INCLUDE_DIRS}>
     ${MEMTAILOR_INCLUDE_DIR}
     ${MATHIC_INCLUDE_DIR}
   )


### PR DESCRIPTION
@mikestillman I think this missing include directory is why you were getting the missing tbb.h errors. Hardcoding paths is never a good idea.