### PR TITLE
Include header for std::numeric_limits

### DIFF
--- a/src/mathicgb/RawVector.hpp
+++ b/src/mathicgb/RawVector.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <cstring>
+#include <limits>
 
 MATHICGB_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Otherwise, mathicgb fails to compile using gcc 11.

Closes: #25