### PR TITLE
add missing header

### DIFF
--- a/src/mathicgb/RawVector.hpp
+++ b/src/mathicgb/RawVector.hpp
@@ -5,6 +5,7 @@
 
 #include <iterator>
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <utility>
 #include <algorithm>


### PR DESCRIPTION
Resolves:
RawVector.hpp:109:43: error: 'numeric_limits' is not a member of 'std'"