### PR TITLE
Install all header files (autotools build)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,8 @@ libmathicgb_la_SOURCES = src/mathicgb/MonoArena.hpp						\
 # The headers that libmathicgb installs.
 mathicgbA_include_HEADERS = src/mathicgb.h
 mathicgbA_includedir = $(includedir)
+mathicgbB_include_HEADERS = $(wildcard src/mathicgb/*.h src/mathicgb/*.hpp)
+mathicgbB_includedir = $(includedir)/mathicgb
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = build/autotools/mathicgb.pc


### PR DESCRIPTION
They are installed in the mathicgb subdirectory of the main include directory.  This was already being done in the CMake build.

As discussed in https://github.com/Macaulay2/M2/pull/2173.