### PR TITLE
TBB 2021

### DIFF
--- a/src/mathicgb/F4MatrixBuilder.cpp
+++ b/src/mathicgb/F4MatrixBuilder.cpp
@@ -134,7 +134,7 @@ void F4MatrixBuilder::buildMatrixAndClear(QuadMatrix& matrix) {
   };
 
   mgb::mtbb::enumerable_thread_specific<ThreadData> threadData([&](){  
-    mgb::mtbb::mutex::scoped_lock guard(mCreateColumnLock);
+    std::lock_guard guard(mCreateColumnLock);
     ThreadData data = {
       QuadMatrixBuilder(
         ring(),
@@ -232,7 +232,7 @@ auto F4MatrixBuilder::createColumn(
   ConstMonoRef monoB,
   TaskFeeder& feeder
 ) -> std::pair<F4MatrixBuilder::LeftRightColIndex, ConstMonoRef> {
-  mgb::mtbb::mutex::scoped_lock lock(mCreateColumnLock);
+  std::lock_guard lock(mCreateColumnLock);
   // see if the column exists now after we have synchronized
   {
     const auto found(ColReader(mMap).findProduct(monoA, monoB));

--- a/src/mathicgb/F4MatrixBuilder.hpp
+++ b/src/mathicgb/F4MatrixBuilder.hpp
@@ -10,6 +10,7 @@
 #include "QuadMatrix.hpp"
 #include "mtbb.hpp"
 #include <vector>
+#include <mutex>
 
 MATHICGB_NAMESPACE_BEGIN
 
@@ -156,7 +157,7 @@ private:
     TaskFeeder& feeder
   );
 
-  mgb::mtbb::mutex mCreateColumnLock;
+  std::mutex mCreateColumnLock;
   ColIndex mLeftColCount;
   ColIndex mRightColCount;
   Mono mTmp;

--- a/src/mathicgb/F4MatrixBuilder2.cpp
+++ b/src/mathicgb/F4MatrixBuilder2.cpp
@@ -158,7 +158,7 @@ public:
 
     mgb::mtbb::enumerable_thread_specific<ThreadData> threadData([&](){  
       // We need to grab a lock since monoid isn't internally synchronized.
-      mgb::mtbb::mutex::scoped_lock guard(mCreateColumnLock);
+      std::lock_guard guard(mCreateColumnLock);
       ThreadData data = {
         *monoid().alloc().release(),
         *monoid().alloc().release()
@@ -306,7 +306,7 @@ public:
     ConstMonoRef monoB,
     TaskFeeder& feeder
   ) {
-    mgb::mtbb::mutex::scoped_lock lock(mCreateColumnLock);
+    std::lock_guard lock(mCreateColumnLock);
     // see if the column exists now after we have synchronized
     {
       const auto found(ColReader(mMap).findProduct(monoA, monoB));
@@ -524,7 +524,7 @@ public:
   const size_t mMemoryQuantum;
 
   /// If you want to modify the columns, you need to grab this lock first.
-  mgb::mtbb::mutex mCreateColumnLock;
+  std::mutex mCreateColumnLock;
 
   /// A monomial for temporary scratch calculations. Protected by
   /// mCreateColumnLock.

--- a/src/mathicgb/FixedSizeMonomialMap.h
+++ b/src/mathicgb/FixedSizeMonomialMap.h
@@ -10,6 +10,7 @@
 #include <limits>
 #include <vector>
 #include <algorithm>
+#include <mutex>
 
 MATHICGB_NAMESPACE_BEGIN
 
@@ -191,7 +192,7 @@ public:
   /// p.first.second is a internal monomial that equals value.first.
   std::pair< std::pair<const mapped_type*, ConstMonoPtr>, bool>
   insert(const value_type& value) {
-    const mgb::mtbb::mutex::scoped_lock lockGuard(mInsertionMutex);
+    const std::lock_guard lockGuard(mInsertionMutex);
     // find() loads buckets with memory_order_consume, so it may seem like
     // we need some extra synchronization to make sure that we have the
     // most up to date view of the bucket that value.first goes in -
@@ -321,7 +322,7 @@ private:
   std::unique_ptr<Atomic<Node*>[]> const mBuckets;
   const PolyRing& mRing;
   memt::BufferPool mNodeAlloc; // nodes are allocated from here.
-  mgb::mtbb::mutex mInsertionMutex;
+  std::mutex mInsertionMutex;
 
 public:
   class const_iterator {

--- a/src/test/F4MatrixBuilder.cpp
+++ b/src/test/F4MatrixBuilder.cpp
@@ -58,12 +58,12 @@ namespace {
 
 TEST(F4MatrixBuilder, Empty) {
   for (int threadCount = 1; threadCount < 4; ++threadCount) {
-    mgb::mtbb::task_scheduler_init scheduler(threadCount);
+    mgb::mtbb::task_arena scheduler(threadCount);
     BuilderMaker maker;
     F4MatrixBuilder& builder = maker.create();
 
     QuadMatrix matrix(maker.ring());
-    builder.buildMatrixAndClear(matrix);
+    scheduler.execute([&builder,&matrix]{builder.buildMatrixAndClear(matrix);});
     ASSERT_EQ(0, matrix.topLeft.rowCount());
     ASSERT_EQ(0, matrix.bottomLeft.rowCount());
     ASSERT_EQ(0, matrix.topLeft.computeColCount());
@@ -75,7 +75,7 @@ TEST(F4MatrixBuilder, Empty) {
 
 TEST(F4MatrixBuilder, SPair) {
   for (int threadCount = 1; threadCount < 4; ++threadCount) {
-    mgb::mtbb::task_scheduler_init scheduler(threadCount);
+    mgb::mtbb::task_arena scheduler(threadCount);
     BuilderMaker maker;
     const Poly& p1 = maker.addBasisElement("a4c2-d");
     const Poly& p2 = maker.addBasisElement("a4b+d");
@@ -84,7 +84,7 @@ TEST(F4MatrixBuilder, SPair) {
     F4MatrixBuilder& builder = maker.create();
     builder.addSPolynomialToMatrix(p1, p2);
     QuadMatrix qm(builder.ring());
-    builder.buildMatrixAndClear(qm);
+    scheduler.execute([&builder,&qm]{builder.buildMatrixAndClear(qm);});
     const char* const str1 = 
       "Left columns: c2d\n"
       "Right columns: bd 1\n"
@@ -105,13 +105,13 @@ TEST(F4MatrixBuilder, SPair) {
 
 TEST(F4MatrixBuilder, OneByOne) {
   for (int threadCount = 1; threadCount < 4; ++threadCount) {
-    mgb::mtbb::task_scheduler_init scheduler(threadCount);
+    mgb::mtbb::task_arena scheduler(threadCount);
     BuilderMaker maker;
     const Poly& p = maker.addBasisElement("a");
     F4MatrixBuilder& builder = maker.create();
     builder.addPolynomialToMatrix(p.leadMono(), p);
     QuadMatrix qm(builder.ring());
-    builder.buildMatrixAndClear(qm);
+    scheduler.execute([&builder,&qm]{builder.buildMatrixAndClear(qm);});
     const char* str = 
       "Left columns: a2\n"
       "Right columns:\n"

--- a/src/test/gb-test.cpp
+++ b/src/test/gb-test.cpp
@@ -262,7 +262,7 @@ spairQueue	reducerType	divLookup	monTable	buchberger	postponeKoszul	useBaseDivis
 
     MATHICGB_ASSERT(Reducer::makeReducerNullOnUnknown(red, ring).get() != 0);
 
-    mgb::mtbb::task_scheduler_init scheduler(threadCount);
+    mgb::mtbb::task_arena scheduler(threadCount);
     if (buchberger) {
       const auto reducer = Reducer::makeReducer
         (Reducer::reducerType(reducerType), ring);
@@ -280,7 +280,9 @@ spairQueue	reducerType	divLookup	monTable	buchberger	postponeKoszul	useBaseDivis
       params.useAutoTailReduction = autoTailReduce;
       params.callback = nullptr;
 
-      auto gb = computeGBClassicAlg(std::move(basis), params);
+      auto gb = scheduler.execute([&basis,&params]{
+         return computeGBClassicAlg(std::move(basis), params);
+      });
 
       Basis initialIdeal(gb.ring());
       for (size_t i = 0; i < gb.size(); ++i) {
@@ -307,7 +309,7 @@ spairQueue	reducerType	divLookup	monTable	buchberger	postponeKoszul	useBaseDivis
         useSingularCriterionEarly,
         spairQueue
       );
-      alg.computeGrobnerBasis();
+      scheduler.execute([&alg]{alg.computeGrobnerBasis();});
       EXPECT_EQ(sigBasisStr, toString(alg.getGB(), 1))
         << reducerType << ' ' << divLookup << ' '
         << monTable << ' ' << ' ' << postponeKoszul << ' '


### PR DESCRIPTION
This works for me on Gentoo (TBB 2021) and Arch (TBB 2020). I also tried it with the `MATHICGB_NO_TBB` flag enabled.

I noticed after I wrote the code that @mikestillman had already made some changes, so feel free to ignore this request if that code is preferred. Mostly since I'd already written this code, I wanted to make it available.

The main change is to use `task_arena` instead of `task_scheduler_init`. `task_arena` seems to be present on the most recent version of TBB 2020, so we should be able to maintain compatibility with most distros, but it'd be great if someone on Ubuntu or Debian can verify.

I only implemented the version of `parallel_do` that is actually used in mathicgb, since I'd expect that the longer term goal is to get rid of the shim code, and use the new version of TBB directly.

The second commit with the mutex changes isn't needed, but since the TBB 2021 code needs to use `std::mutex` anyways, it might be good to just use it universally.

