### PR TITLE
Add configure option to disable building command line interface

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,6 +76,8 @@ pkgconfig_DATA = build/autotools/mathicgb.pc
 # that are necessary to build the project. EXTRA_DIST specifies files
 # to include beyond those used in the build process.
 EXTRA_DIST = autogen.sh
+
+if CLI
 dist_man_MANS = doc/mgb.1
 
 bin_PROGRAMS = mgb
@@ -89,6 +91,7 @@ mgb_SOURCES = src/cli/GBMain.cpp src/cli/CommonParams.hpp		\
   src/cli/SigGBAction.hpp src/cli/SigGBAction.cpp			\
   src/cli/HelpAction.hpp src/cli/HelpAction.cpp
 mgb_LDADD = $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lpthread
+endif
 
 # set up tests to run on "make check"
 if with_gtest

--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,17 @@ DEPS_LIBS="$MEMTAILOR_LIBS $MATHIC_LIBS $TBB_LIBS $RT_LIBS"
 AC_SUBST(DEPS_CFLAGS)
 AC_SUBST(DEPS_LIBS)
 
+AC_ARG_ENABLE([cli],
+    AS_HELP_STRING([--disable-cli],
+	[disable building the command line interface]),
+    [case "${enableval}" in
+	yes) cli=true ;;
+	no)  cli=false ;;
+	*) AC_MSG_ERROR([bad value "${enableval}" for --enable-cli]) ;;
+     esac],
+    [cli=true])
+AM_CONDITIONAL([CLI], [test x$cli = xtrue])
+
 # Enable optional maintainer mode (off by default)
 dnl AM_MAINTAINER_MODE turns off automatic reconstruction of the build
 dnl files if the source build files have changed. A developer will want


### PR DESCRIPTION
This adds an option `--disable-cli` to the `configure` script to disable building the `mgb` command line interface.

My plan is to use this in https://github.com/Macaulay2/M2/pull/2394, as `mgb` is unnecessary for building Macaulay2 (and building it was causing `-fopenmp` errors in the Github macOS builds).   It's currently possible to skip building `mgb` by specifying various targets to `make` (see https://github.com/Macaulay2/M2/pull/2394/commits/3a0c74a67f9611f38dec774fc46d99098aaba554 and https://github.com/Macaulay2/M2/pull/2394/commits/0f6f5417e67f42c1703e12061fd7feb5a63aabad), but this would be simpler.