### PR TITLE
Include header for "assert" when building w/o TBB

### DIFF
--- a/src/mathicgb/mtbb.hpp
+++ b/src/mathicgb/mtbb.hpp
@@ -75,6 +75,7 @@ namespace mtbb {
 #include <ctime>
 #include <algorithm>
 #include <chrono>
+#include <cassert>
 
 namespace mtbb {
 


### PR DESCRIPTION
Otherwise, we get:

```
make[1]: Entering directory '/<<PKGBUILDDIR>>'
g++ -DPACKAGE_NAME=\"mathicgb\" -DPACKAGE_TARNAME=\"mathicgb\" -DPACKAGE_VERSION=\"1.0\" -DPACKAGE_STRING=\"mathicgb\ 1.0\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DHAVE_CXX11=1 -DPACKAGE=\"mathicgb\" -DVERSION=\"1.0\" -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -I.  -I./ -I./src/ -DMATHICGB_NO_TBB -I/usr/src/gtest/include -I/usr/src/gtest -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -c -o src/cli/GBMain.o src/cli/GBMain.cpp
In file included from src/cli/CommonParams.hpp:6,
                 from src/cli/GBAction.hpp:7,
                 from src/cli/GBMain.cpp:5:
./src/mathicgb/mtbb.hpp: In member function ‘void mtbb::mutex::lock()’:
./src/mathicgb/mtbb.hpp:101:7: error: ‘assert’ was not declared in this scope
  101 |       assert(!mLocked); // deadlock
      |       ^~~~~~
./src/mathicgb/mtbb.hpp:78:1: note: ‘assert’ is defined in header ‘<cassert>’; did you forget to ‘#include <cassert>’?
   77 | #include <chrono>
  +++ |+#include <cassert>
   78 |
```

(from https://buildd.debian.org/status/fetch.php?pkg=mathicgb&arch=hurd-i386&ver=1.0%7Egit20220311-1&stamp=1647033452&raw=0)