### PR TITLE
Detect TBB 2021 on 32-bit systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,10 +110,12 @@ AC_ARG_WITH([tbb], AS_HELP_STRING(
 AS_IF([test "x$with_tbb" == "x"], [with_tbb="detect"])
 AS_IF(
   [test "x$with_tbb" == "xdetect"],
-  [PKG_CHECK_MODULES([TBB], [tbb], [with_tbb="yes"], [with_tbb="no";
-    AC_MSG_WARN([TBB not detected. Compiling without multithreading and without precise timing.])
+  [PKG_CHECK_MODULES([TBB], [tbb], [with_tbb="yes"],
+    [PKG_CHECK_MODULES([TBB], [tbb32], [with_tbb="yes"], [with_tbb="no";
+      AC_MSG_WARN([TBB not detected. Compiling without multithreading and without precise timing.])])
   ])],
-  [test "x$with_tbb" == "xyes"], [PKG_CHECK_MODULES([TBB], [tbb])],    
+  [test "x$with_tbb" == "xyes"], [PKG_CHECK_MODULES([TBB], [tbb],,
+    [PKG_CHECK_MODULES([TBB], [tbb32])])],
   [test "x$with_tbb" == "xno"], [],
   [AC_MSG_ERROR([invalid value $with_tbb for with_tbb.])]
 )


### PR DESCRIPTION
On 32-bit systems, the pkg-config file is `tbb32.pc` instead of `tbb.pc`.