### PR TITLE
Fix Warnings

### DIFF
--- a/src/mathicgb/F4Reducer.cpp
+++ b/src/mathicgb/F4Reducer.cpp
@@ -339,7 +339,7 @@ std::unique_ptr<Reducer> makeF4Reducer(
     make_unique<F4Reducer>(ring, F4Reducer::OldType) :
     make_unique<F4Reducer>(ring, F4Reducer::NewType);
   reducer->writeMatricesTo(file, minEntries);
-  return std::move(reducer);
+  return reducer;
 }
 
 MATHICGB_REGISTER_REDUCER(

--- a/src/mathicgb/MathicIO.hpp
+++ b/src/mathicgb/MathicIO.hpp
@@ -300,7 +300,7 @@ auto MathicIO<M, BF>::readOrder(
     componentsAscendingDesired,
     schreyering
   );
-  return std::move(order);
+  return order;
 }
 
 template<class M, class BF>

--- a/src/mathicgb/MonoMonoid.hpp
+++ b/src/mathicgb/MonoMonoid.hpp
@@ -1496,6 +1496,7 @@ public:
       //const_iterator(const const_iterator& it):
       //  mIt(it.mIt), mEntriesPerMono(it.mEntriesPerMono) {}
       const_iterator(const const_iterator& it) = default;
+      const_iterator& operator=(const const_iterator& it) = default;
 
       
       bool operator==(const const_iterator& it) const {return mIt == it.mIt;}

--- a/src/mathicgb/MonoProcessor.hpp
+++ b/src/mathicgb/MonoProcessor.hpp
@@ -28,6 +28,7 @@ public:
     const bool componentsAscendingDesired,
     const bool schreyering
   ):
+    mOrderFromLeft(false),
     mComponentsAscendingDesired(componentsAscendingDesired),
     mComponentCount(0),
     mSchreyering(schreyering),

--- a/src/mathicgb/PrimeField.hpp
+++ b/src/mathicgb/PrimeField.hpp
@@ -222,7 +222,7 @@ auto PrimeField<T>::product(
 ) const -> Element {
   typedef typename PrimeFieldInternal::ModularProdType<T>::type BigT;
   BigT bigProd = static_cast<BigT>(a.value()) * b.value();
-  MATHICGB_ASSERT(a.value() == 0 || bigProd / a.value() == b.value());
+  MATHICGB_ASSERT(a.value() == 0 || bigProd / a.value() == static_cast<BigT>(b.value()));
   return Element(static_cast<T>(bigProd % charac()));
 }
 

--- a/src/mathicgb/SPairs.cpp
+++ b/src/mathicgb/SPairs.cpp
@@ -356,7 +356,6 @@ bool SPairs::simpleBuchbergerLcmCriterion(
   };
 
   bool applies = false;
-  bool almostApplies = false;
   {
     Criterion criterion(a, b, lcmAB, *this);
     if (mUseBuchbergerLcmHitCache) {
@@ -418,8 +417,6 @@ bool SPairs::simpleBuchbergerLcmCriterion(
         mBuchbergerLcmHitCache[b] = criterion.hit();
       }
     }
-    if (!applies)
-      almostApplies = criterion.almostApplies();
   }
 
   if (applies)

--- a/src/mathicgb/SparseMatrix.cpp
+++ b/src/mathicgb/SparseMatrix.cpp
@@ -566,26 +566,14 @@ void SparseMatrix::writePBM(FILE* file) {
     const auto end = rowEnd(row);
     auto it = rowBegin(row);
 
-    unsigned char byte = 0;
-    unsigned int bit = (1 << 8);
     for (ColIndex col = 0; col < colCount; ++col) {
       if (it != end && col == it.index()) {
         fputc('1', file);
-        byte |= bit;
         ++it;
       } else
         fputc('0', file);
-
-      bit >>= 1;
-      if (bit == 0) {
-//        fputc(byte, file);
-        byte = 0;
-        bit = (1 << 8);
-      }
     }
     fputc('\n', file);
-   // if (bit != (1 << 8))
-     // fputc(byte, file);
   }
 }
 

--- a/src/mathicgb/stdinc.h
+++ b/src/mathicgb/stdinc.h
@@ -79,7 +79,7 @@
 
 #define MATHICGB_NO_INLINE __attribute__((noinline))
 #define MATHICGB_INLINE __attribute__((always_inline)) inline
-#define MATHICGB_ASSUME(X)
+#define MATHICGB_ASSUME(X) ((void)0)
 #define MATHICGB_ASSUME_AND_MAY_EVALUATE(X) do {if(!(X)){MATHICGB_UNREACHABLE;}while(0)}
 #define MATHICGB_RETURN_NO_ALIAS __attribute__(malloc)
 #define MATHICGB_NOTHROW __attribute__(nothrow)
@@ -103,8 +103,8 @@
 
 #define MATHICGB_NO_INLINE
 #define MATHICGB_INLINE inline
-#define MATHICGB_ASSUME(X)
-#define MATHICGB_ASSUME_AND_MAY_EVALUATE(X)
+#define MATHICGB_ASSUME(X) ((void)0)
+#define MATHICGB_ASSUME_AND_MAY_EVALUATE(X) ((void)0)
 #define MATHICGB_RETURN_NO_ALIAS
 #define MATHICGB_NOTHROW
 #define MATHICGB_PURE
@@ -137,7 +137,7 @@
 #define MATHICGB_IF_DEBUG(X) X
 #else
 #define MATHICGB_ASSERT(X) MATHICGB_ASSUME(X)
-#define MATHICGB_ASSERT_NO_ASSUME(X)
+#define MATHICGB_ASSERT_NO_ASSUME(X) ((void)0)
 #define MATHICGB_IF_DEBUG(X)
 #endif
 
@@ -145,7 +145,7 @@
 // for asserts that take a long time.
 #define MATHICGB_SLOW_ASSERT(X) MATHICGB_ASSERT(X)
 #else
-#define MATHICGB_SLOW_ASSERT(X)
+#define MATHICGB_SLOW_ASSERT(X) ((void)0)
 #endif
 
 /// Concatenates A to B without expanding A and B. This is achieved since

--- a/src/test/MathicIO.cpp
+++ b/src/test/MathicIO.cpp
@@ -94,10 +94,8 @@ TEST(MathicIO, ReadWriteMonomial) {
 
     // directly make monomial
     auto monoSet = m.alloc();
-    if (var1 != -1)
-      m.setExponent(var1, exp1, *monoSet);
-    if (var2 != -1)
-      m.setExponent(var2, exp2, *monoSet);
+    m.setExponent(var1, exp1, *monoSet);
+    m.setExponent(var2, exp2, *monoSet);
     if (doComponent)
       m.setComponent(component, *monoSet);
     ASSERT_TRUE(m.equal(*monoRead, *monoSet)) << "Str: " << str;

--- a/src/test/MathicIO.cpp
+++ b/src/test/MathicIO.cpp
@@ -71,6 +71,8 @@ TEST(MathicIO, ReadWriteMonomial) {
   typedef Monoid::VarIndex VarIndex;
   typedef Monoid::Exponent Exponent;
   static const auto NoComponent = static_cast<Exponent>(-1);
+  static const auto NoExponent = NoComponent;
+  static const auto NoVar = static_cast<VarIndex>(-1);
 
   Monoid m(28);
 
@@ -94,8 +96,10 @@ TEST(MathicIO, ReadWriteMonomial) {
 
     // directly make monomial
     auto monoSet = m.alloc();
-    m.setExponent(var1, exp1, *monoSet);
-    m.setExponent(var2, exp2, *monoSet);
+    if(var1!=NoVar)
+        m.setExponent(var1, exp1, *monoSet);
+    if(var2!=NoVar)
+        m.setExponent(var2, exp2, *monoSet);
     if (doComponent)
       m.setComponent(component, *monoSet);
     ASSERT_TRUE(m.equal(*monoRead, *monoSet)) << "Str: " << str;
@@ -107,15 +111,15 @@ TEST(MathicIO, ReadWriteMonomial) {
     ASSERT_EQ(correctStr, out.str());
   };
 
-  check("1", NoComponent,  -1,-1,  -1,-1,  0);
-  check("1<0>", 0,  -1,-1,  -1,-1,  0);
-  check("1<1>", 1,  -1,-1,  -1,-1,  0);
-  check("1<999>", 999,  -1,-1,  -1,-1,  0);
+  check("1", NoComponent,  NoVar,NoExponent,  NoVar,NoExponent,  0);
+  check("1<0>", 0,  NoVar,NoExponent,  NoVar,NoExponent,  0);
+  check("1<1>", 1,  NoVar,NoExponent,  NoVar,NoExponent,  0);
+  check("1<999>", 999,  NoVar,NoExponent,  NoVar,NoExponent,  0);
 
-  check("a1", NoComponent,  0,1,  -1,-1,  "a");
-  check("b10<0>", 0,  1,10,  -1,-1,  0);
-  check("A11", NoComponent,  26,11, -1,-1,  0);
-  check("B99<1>", 1,   27,99,  -1,-1,  0);
+  check("a1", NoComponent,  0,1,  NoVar,NoExponent,  "a");
+  check("b10<0>", 0,  1,10,  NoVar,NoExponent,  0);
+  check("A11", NoComponent,  26,11, NoVar,NoExponent,  0);
+  check("B99<1>", 1,   27,99,  NoVar,NoExponent,  0);
 
   check("ab", NoComponent,  0,1,  1,1,  0);
   check("ba", NoComponent,  0,1,  1,1,  "ab");


### PR DESCRIPTION
This fixes a few compile warnings coming from mathicgb. Here's a summary of the less straightforward changes:

1. `std::move` is counterproductive when used in a return, returns already try to use the move constructor/assignment when possible.
2. When we provide a copy constructor, we should provide an assignment operator.
3. `MATHICGB_ASSERT` and friends should always give a non-empty expression, the `((void)0)` trick is the same thing the standard `assert` does