### PR TITLE
Skip isProductOfHintTrue/isTwoProductsOfHintTrue on big-endian archs

### DIFF
--- a/src/mathicgb/MonoMonoid.hpp
+++ b/src/mathicgb/MonoMonoid.hpp
@@ -573,7 +573,8 @@ public:
     // for unaligned access. Performance seems to be no worse than for using
     // 32 bit integers directly.
 
-    if (sizeof(Exponent) != 4 || (!StoreHash && !StoreOrder))
+    if (sizeof(Exponent) != 4 || (!StoreHash && !StoreOrder) ||
+        __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
       return isProductOf(a, b, ab);
 
     uint64 orOfXor = 0;
@@ -602,7 +603,8 @@ public:
     ConstMonoRef a1b,
     ConstMonoRef a2b
   ) const {
-    if (sizeof(Exponent) != 4 || (!StoreHash && !StoreOrder))
+    if (sizeof(Exponent) != 4 || (!StoreHash && !StoreOrder) ||
+        __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
       return (isProductOf(a1, b, a1b) && isProductOf(a2, b, a2b));
 
     uint64 orOfXor = 0;


### PR DESCRIPTION
This is an alternate proprosal for fixing #3.  Then other proposal (#9) doesn't work for me in its current state.  (I'm still using the [original form of that PR](https://github.com/Macaulay2/mathicgb/commit/d8ae074c7f7655c3b85c2089cd7a05a98a70a46a) in the Debian package, but Dan pointed out some bugs with it.)

I actually submitted this version as a PR last summer when mathicgb was in the `e` directory (https://github.com/Macaulay2/M2/pull/2172), but it was moved back to a submodule before it could be merged.  I noticed that the Fedora mathicgb is [already using this version](https://src.fedoraproject.org/rpms/mathicgb/blob/rawhide/f/mathicgb-endian.patch).