### PR TITLE
Call the destructor explicitly when using placment new

### DIFF
--- a/src/mathicgb/ModuleMonoSet.cpp
+++ b/src/mathicgb/ModuleMonoSet.cpp
@@ -24,16 +24,16 @@ public:
   ConcreteModuleMonoSet(const Monoid& monoid, const size_t componentCount):
     mMonoid(monoid),
     mComponentCount(componentCount),
-    mLookups(reinterpret_cast<Lookup*>(
-      new char[sizeof(Lookup) * componentCount]
-    ))
+    mLookups(std::allocator<Lookup>().allocate(mComponentCount))
   {
     for (size_t component = 0; component < componentCount; ++component)
       new (&mLookups[component]) Lookup(monoid);
   }
 
   virtual ~ConcreteModuleMonoSet() {
-    delete[] reinterpret_cast<char*>(mLookups);
+    for(size_t component = 0; component < mComponentCount; ++component)
+      mLookups[component].~Lookup();
+    std::allocator<Lookup>().deallocate(mLookups, mComponentCount);
   }
 
   virtual bool insert(ConstMonoRef m) {

--- a/src/mathicgb/SigSPairQueue.cpp
+++ b/src/mathicgb/SigSPairQueue.cpp
@@ -206,7 +206,6 @@ namespace mathic {
         MATHICGB_ASSERT(pd != nullptr);
         MATHICGB_ASSERT(col > row);
         conf.monoid().freeRaw(*pd);
-        pd->~auto();
       }
     };
   }

--- a/src/mathicgb/SigSPairQueue.cpp
+++ b/src/mathicgb/SigSPairQueue.cpp
@@ -206,6 +206,7 @@ namespace mathic {
         MATHICGB_ASSERT(pd != nullptr);
         MATHICGB_ASSERT(col > row);
         conf.monoid().freeRaw(*pd);
+        pd->~auto();
       }
     };
   }


### PR DESCRIPTION
`Lookup` has a non-trivial destructor, so the failure to call it's destructor in the destructor of `ConcreteModuleMonoSet` was causing memory leaks. I added a call to the destructor one one other place using placement new, but not all of them. There are a couple places where the object involved is trivially destructible, and calling the destructors in the right places is not trivial.

Draft for now, since the corresponding M2 pull request is a draft.