### PR TITLE
Make sure to link with libatomic when using TBB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,9 @@ AS_IF(
 )
 AS_IF([test "x$with_tbb" == "xno"], [TBB_CFLAGS="-DMATHICGB_NO_TBB"])
 
+AS_IF([test "x$with_tbb" = "xyes" && echo "$TBB_LIBS" | grep "\-latomic"],
+  [], [TBB_LIBS="$TBB_LIBS -latomic"])
+
 dnl ----- The librt dependency
 dnl On Linux TBB calls clock_gettime, which requires librt, but librt is not
 dnl linked in automatically. So we need to check for that.


### PR DESCRIPTION
The Debian TBB package, prior to TBB 2021, shipped a [pkg-config file](https://salsa.debian.org/science-team/tbb/-/blob/635c9f649e9c5882fbb1b66b629b8360e7fcd2d1/debian/tbb.pc.in) that always inserted `-latomic` into linker flags.  However, with the release of TBB 2021, upstream now ships [its own pkg-config file](https://github.com/oneapi-src/oneTBB/blob/master/integration/pkg-config/tbb.pc.in) that does not include this flag.  This was causing linking errors on [armel](https://buildd.debian.org/status/fetch.php?pkg=mathicgb&arch=armel&ver=1.0%7Egit20220426-1%2Bb1&stamp=1655134224&raw=0) and [mipsel](https://buildd.debian.org/status/fetch.php?pkg=mathicgb&arch=mipsel&ver=1.0%7Egit20220426-1%2Bb1&stamp=1655134166&raw=0) machines:

```
libtool: link: g++ -g -O2 "-ffile-prefix-map=/<<PKGBUILDDIR>>=." -fstack-protector-strong -Wformat -Werror=format-security -Wl,-z -Wl,relro -Wl,-z -Wl,now -o .libs/mgb src/cli/GBMain.o src/cli/CommonParams.o src/cli/GBAction.o src/cli/GBCommonParams.o src/cli/MatrixAction.o src/cli/SigGBAction.o src/cli/HelpAction.o  ./.libs/libmathicgb.so -lmemtailor -lmathic -ltbb -lpthread
/usr/bin/ld: /usr/lib/gcc/arm-linux-gnueabi/11/../../../arm-linux-gnueabi/libtbb.so: undefined reference to `__atomic_fetch_sub_8'
/usr/bin/ld: /usr/lib/gcc/arm-linux-gnueabi/11/../../../arm-linux-gnueabi/libtbb.so: undefined reference to `__atomic_load_8'
/usr/bin/ld: ./.libs/libmathicgb.so: undefined reference to `__atomic_fetch_add_8'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:1043: mgb] Error 1
```
Possibly related: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104248