### PR TITLE
set MATHICGB_NO_TBB with with_tbb=off is given

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ add_compile_options(
   -DPACKAGE_BUGREPORT=""
   -DPACKAGE_URL=""
   -DPACKAGE="${PROJECT_NAME}"
-  $<$<NOT:$<BOOL:${with_tbb}>>:-DMATHICGB_NO_TBB>
   -Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-unused-variable -Wno-sign-compare
   )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,10 @@ add_library(mathicgb STATIC
   mathicgb/stdinc.h
   )
 
+target_compile_options(mathicgb PUBLIC
+  $<$<NOT:$<BOOL:${with_tbb}>>:-DMATHICGB_NO_TBB>
+  )
+
 target_link_libraries(mathicgb
   memtailor mathic Threads::Threads
   $<$<BOOL:${with_tbb}>:TBB::tbb>

--- a/src/mathicgb/mtbb.hpp
+++ b/src/mathicgb/mtbb.hpp
@@ -74,6 +74,7 @@ namespace mtbb {
 #include <vector>
 #include <ctime>
 #include <algorithm>
+#include <memory>
 #include <chrono>
 #include <cassert>
 


### PR DESCRIPTION
Otherwise M2 doesn't compile with `WITH_TBB=off`.