### PR TITLE
Fix a couple build flags for tests (autotools)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -107,7 +107,8 @@ check_PROGRAMS=$(TESTS)
 # this prevents g++ 4.8.2 from crashing and churning through memory when compiling under Ubuntu 64 14.04.1
 src/test/MonoMonoid.o src/test/Range.o : CXXFLAGS += -O0
 
-unittest_LDADD = $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lpthread -lgtest
+unittest_LDADD = $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lgtest
+unittest_LDFLAGS = -pthread
 
 test_LIBS=
 unittest_SOURCES=src/test/Range.cpp						\

--- a/Makefile.am
+++ b/Makefile.am
@@ -107,7 +107,7 @@ check_PROGRAMS=$(TESTS)
 # this prevents g++ 4.8.2 from crashing and churning through memory when compiling under Ubuntu 64 14.04.1
 src/test/MonoMonoid.o src/test/Range.o : CXXFLAGS += -O0
 
-unittest_LDADD = $(DEPS_LIBS) $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lpthread -lgtest
+unittest_LDADD = $(top_builddir)/libmathicgb.la $(DEPS_LIBS) -lpthread -lgtest
 
 test_LIBS=
 unittest_SOURCES=src/test/Range.cpp						\


### PR DESCRIPTION
* `-pthread` is more portable than `-lpthread`, so we use it.  It also fixes linking errors when using a gtest static library, where we would have wanted `-lpthread` *after* `-lgtest`, not before.
* Remove redundant `DEPS_LIBS`.